### PR TITLE
fix: when no funds show only once metamask to sign

### DIFF
--- a/src/shared/@ocean/utils/computeToData.ts
+++ b/src/shared/@ocean/utils/computeToData.ts
@@ -174,7 +174,7 @@ export async function handleComputeOrder(
        - no validOrder -> we need to call startOrder, to pay 1 DT & providerFees
     */
 	if (order.providerFee && order.providerFee.providerFeeAmount) {
-		await approveWei(
+		const approve = await approveWei(
 			payerAccount,
 			config,
 			await payerAccount.getAddress(),
@@ -182,6 +182,9 @@ export async function handleComputeOrder(
 			asset.services[0].datatokenAddress,
 			order.providerFee.providerFeeAmount
 		);
+    if (!approve) {
+      return;
+    }
 	}
 	if (order.validOrder) {
 		if (!order.providerFee) return order.validOrder;


### PR DESCRIPTION
Fixes #28 .

Changes proposed in this PR:

- If a transaction fails, don't continue the process and fire more transactions
